### PR TITLE
機能追加　お問い合わせ詳細画面の作成

### DIFF
--- a/src/main/java/com/github/sa_cchu/stock/controller/InquiryController.java
+++ b/src/main/java/com/github/sa_cchu/stock/controller/InquiryController.java
@@ -61,7 +61,7 @@ public class InquiryController {
 		model.addAttribute("isAdmin", isAdmin(user));	
 		// Enumに記載しているステータス情報を選択肢として画面に渡す。
 		model.addAttribute("statusList", StatusEnum.values());
-		// statusId → Enum に型に変換する。（すべてを選択している場合はnullで使用）
+		// statusId → Enum に変換する。（すべてを選択している場合はnullで使用）
 	    StatusEnum statusEnum = null;
 	    if (status != null) {
 	        statusEnum = StatusEnum.fromId(status);
@@ -107,7 +107,6 @@ public class InquiryController {
 	public String sendInquiry(@Validated @ModelAttribute InquiryForm inquiryForm,
 			BindingResult result, @AuthenticationPrincipal User user,
 			RedirectAttributes redirectAttributes, Model model) {
-
 		// 管理者宛てに送信する場合、Formクラスにバリデーションを実装すると
 		// 不要なバリデーションが機能してしまうため、連携先選択のバリデーションをcontrollerで行う。
 		if (!ADMIN_ID.equals(inquiryForm.getAuthorityId()) && inquiryForm.getTargetId() == null) {
@@ -138,11 +137,50 @@ public class InquiryController {
 		return "redirect:/inquiry/create";
 	}
 
-	// TODO あとで実装予定
-	//	@GetMapping("/detail")
-	//	public String viewInquiryCreate(@Validated @ModelAttribute InquiryForm inquiryForm) {
-	//		return "/inquiry/create";
-	//	}
+    /**
+     * お問い合わせIDをもとにお問い合わせ詳細を表示する
+     * @param inquiryForm
+     * @param id
+     * @param model
+     * @return idに紐づいたお問い合わせ詳細画面
+     */
+	@GetMapping("/detail")
+	public String viewInquiryCreate(@RequestParam("id") Integer id, Model model){
+		// Enumに記載しているステータス情報を選択肢として画面に渡す。
+		model.addAttribute("statusList", StatusEnum.values());
+		InquiryListDto inquiry = inquiryService.getInquiryById(id);
+	    model.addAttribute("inquiry", inquiry);
+		// 詳細情報を取得してを表示する。
+		return "/inquiry/detail";
+	}
+	/**
+	 * お問い合わせ詳細画面で行われたステータス変更を更新する。
+	 * @param id
+	 * @param status
+	 * @return 更新完了メッセージと詳細画面
+	 */
+	@PostMapping("/updateStatus")
+	public String updateStatus(@RequestParam Integer id, @RequestParam Integer status,
+			RedirectAttributes redirectAttributes){
+		try {
+			// statusId → Enum に変換する。（すべてを選択している場合はnullで使用）
+		    StatusEnum statusEnum = null;
+		    if (status != null) {
+		        statusEnum = StatusEnum.fromId(status);
+		    }
+		    // 問い合わせIDに紐づくお問い合わせのステータスを更新する。
+		    inquiryService.updateStatus(id, statusEnum);
+		    // 更新が成功した場合、メッセージを追加し画面で表示する。
+		    redirectAttributes.addFlashAttribute("successMessage", "ステータスを更新しました");
+		} catch (Exception e) {
+			// 空データだった場合やデータ取得に失敗した場合、メッセージを追加し画面で表示する。
+	        redirectAttributes.addFlashAttribute("errorMessage", "ステータスの更新に失敗しました");
+	        // ログ出力する。
+	        e.printStackTrace();
+		}
+	    // 更新完了メッセージを出力して再度詳細画面を表示する。
+	    return "redirect:/inquiry/detail?id=" + id;
+	}
 
 	/**
 	 * ログインユーザーが管理者かどうか判定するメソッド

--- a/src/main/java/com/github/sa_cchu/stock/repository/InquiryRepository.java
+++ b/src/main/java/com/github/sa_cchu/stock/repository/InquiryRepository.java
@@ -64,4 +64,28 @@ public interface InquiryRepository extends JpaRepository<Inquery, Integer> {
 	        Integer shopId,
 	        Integer warehouseId
     );
+    
+    /**
+     * お問い合わせ詳細取得用
+     * 
+     * @param id
+     * @return
+     */
+    @Query("""
+    	    SELECT new com.github.sa_cchu.stock.dto.InquiryListDto(
+    	        i.inqueryId,
+    	        i.inqueryDetail,
+    	        i.inqueryDate,
+    	        u.authority.authorityId,
+    	        COALESCE(s.shopName, w.warehouseName),
+    	        u.userName,
+    	        i.inqueryStatus
+    	    )
+    	    FROM Inquery i
+    	        JOIN i.user u
+    	        LEFT JOIN u.shop s
+    	        LEFT JOIN u.warehouse w
+    	    WHERE i.inqueryId = :id
+    	""")
+    	InquiryListDto findInquiryById(Integer id);
 }

--- a/src/main/java/com/github/sa_cchu/stock/service/InquiryService.java
+++ b/src/main/java/com/github/sa_cchu/stock/service/InquiryService.java
@@ -124,4 +124,42 @@ public class InquiryService {
 		// お問い合わせ情報をDBに登録する。
 		inquiryRepository.save(inquiry);
 	}
+	
+	/**
+	 * お問い合わせ詳細を取得する。
+	 * @param id お問い合わせID
+	 * @return
+	 */
+	public InquiryListDto getInquiryById(Integer id){
+		// 指定されたIDのお問い合わせ情報を取得する
+		InquiryListDto dto = inquiryRepository.findInquiryById(id);
+		// DTOに含まれる authorityId（数値）から、Enumを使用して画面表示用の権限名へ変換する 
+		String authorityName = AuthorityTypeEnum 
+			// 権限IDからEnumを取得する
+			.fetchAuthorityType(dto.getAuthorityId()) 
+			// 権限IDからEnumを取得する。 
+			.getDisplayName(); 
+			// 画面表示用の名称を取得し、 DTOに表示用の権限名をセットする。 
+			dto.setDisplayAuthorityName(authorityName); 
+		// 変換済みのDTOを返却する。 
+		return dto;
+    }
+	/**
+	 * お問い合わせ詳細画面で変更されたステータスを更新する。
+	 *  <p>画面から送信されたステータスは {@link StatusEnum} で受け取り、
+	 * DBで管理している文字列形式（未対応 / 対応中 / 対応済）へ変換して対象のお問い合わせレコードを更新する。</p>
+	 * @param id 更新対象のお問い合わせID
+	 * @param statusEnum 更新するステータス（Enum）
+	 */
+	@Transactional
+	public void updateStatus(Integer id, StatusEnum statusEnum) {
+		// ステータス情報をEnum → DB用文字列に変換する（未対応/対応中/対応済）
+	    String status = statusEnum != null
+	            ? statusEnum.getDisplayStatusName()
+	            : null;
+	    // 指定されたIDのお問い合わせ情報を取得する
+	    Inquery inquiry = inquiryRepository.findById(id).orElseThrow();
+	    // ステータスを更新する
+	    inquiry.setInqueryStatus(status);
+	}
 }

--- a/src/main/resources/templates/inquiry/detail.html
+++ b/src/main/resources/templates/inquiry/detail.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: layout">
+
+<div th:fragment="content">
+	<!-- 中身 -->
+	<h1 class="mb-3">お問い合わせ詳細</h1>
+	
+	<!-- ボタン -->
+	<div class="mt-4 mb-4">
+		<a th:href="@{/inquiry/list}" class="btn btn-secondary">お問い合わせ一覧に戻る</a>
+	</div>
+	<!-- お問い合わせIDから取得した詳細情報 -->
+	<div class="card shadow-sm">
+		<div class="card-body">
+			<!-- 更新成功メッセージを表示 -->
+			<div th:if="${successMessage}" class="successMessage alert alert-success">
+			    <span th:text="${successMessage}"></span>
+			</div>
+			<!-- 更新失敗メッセージを表示 -->
+			<div th:if="${errorMessage}" class="alert alert-danger">
+			    <span th:text="${errorMessage}"></span>
+			</div>
+			<form th:action="@{/inquiry/updateStatus}" method="post">
+				<!-- お問い合わせID情報（非表示） -->
+				<input type="hidden" name="id" th:value="${inquiry.inquiryId}">
+				<!-- ステータス -->
+				<div class="border rounded p-3 mb-4 bg-light">
+				    <h5 class="fw-bold mb-3">ステータス変更</h5>
+
+				    <!-- 現在のステータス -->
+				    <div class="mb-2">
+				        <span class="fw-bold">現在：</span>
+				        <span class="badge bg-secondary"
+				              th:text="${inquiry.inquiryStatus}"></span>
+				    </div>
+
+				    <!-- ステータス変更 -->
+				    <div class="d-flex align-items-center gap-4">
+				        <select name="status" class="form-select w-auto">
+				            <option th:each="st : ${statusList}" 
+				                    th:value="${st.statusId}" 
+				                    th:text="${st.displayStatusName}"
+				                    th:selected="${st.displayStatusName == inquiry.inquiryStatus}">
+				            </option>
+				        </select>
+				        <button class="btn btn-primary">ステータスを更新</button>
+				    </div>
+				</div>
+				<!-- 問い合わせ内容 -->
+				<div class="row mb-3">
+					<label class="col-sm-3 col-form-label fw-bold">問い合わせ内容</label>
+					<div class="col-sm-9">
+						<p class="form-control-plaintext" style="white-space: pre-wrap;"
+							th:text="${inquiry.inquiryDetail}">
+						</p>
+					</div>
+				</div>
+				<!-- 送信日時 -->
+				<div class="row mb-3">
+					<label class="col-sm-3 col-form-label fw-bold">送信日時</label>
+					<div class="col-sm-9">
+						<p class="form-control-plaintext"
+							th:text="${#temporals.format(inquiry.inquiryDate,'yyyy/MM/dd HH:mm')}">
+						</p>
+					</div>
+				</div>
+				
+				<!-- 権限 -->
+				<div class="row mb-3">
+					<label class="col-sm-3 col-form-label fw-bold">権限</label>
+					<div class="col-sm-9">
+						<p class="form-control-plaintext" th:text="${inquiry.displayAuthorityName}">
+						</p>
+					</div>
+				</div>
+				<!-- 所属 -->
+				<div class="row mb-3">
+					<label class="col-sm-3 col-form-label fw-bold">所属</label>
+					<div class="col-sm-9">
+						<p class="form-control-plaintext" th:text="${inquiry.locationName}">
+						</p>
+					</div>
+				</div>
+				<!-- 名前 -->
+				<div class="row mb-3">
+					<label class="col-sm-3 col-form-label fw-bold">名前</label>
+					<div class="col-sm-9">
+						<p class="form-control-plaintext" th:text="${inquiry.userName}">
+						</p>
+					</div>
+				</div>
+			</form>
+		</div>
+	</div>
+</html>


### PR DESCRIPTION
・一覧画面の各お問い合わせのリンク先から遷移
・一覧画面同様の値を取得し各お問い合わせIDと紐づく情報を表示。
・お問い合わせ内容を全て表示
・ステータスの変更が可能。